### PR TITLE
Correcting unit test file names

### DIFF
--- a/Framework/jmaqs-appium/src/test/java/com/magenic/jmaqs/appium/AppiumConfigUnitTest.java
+++ b/Framework/jmaqs-appium/src/test/java/com/magenic/jmaqs/appium/AppiumConfigUnitTest.java
@@ -9,7 +9,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-public class AppiumConfigUnitTests {
+public class AppiumConfigUnitTest {
 
     @Test
     public void testGetMobileDeviceUDID() throws Exception {

--- a/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/ActionBuilderUnitTest.java
+++ b/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/ActionBuilderUnitTest.java
@@ -13,7 +13,7 @@ import org.testng.annotations.Test;
 /**
  * Unit tests for the ActionBuilder class.
  */
-public class ActionBuilderUnitTests extends BaseSeleniumTest {
+public class ActionBuilderUnitTest extends BaseSeleniumTest {
 
   /**
    * Url for the automation page.

--- a/Framework/jmaqs-utilities/src/test/java/com/magenic/jmaqs/utilities/GenericWaitNotParallelUnitTest.java
+++ b/Framework/jmaqs-utilities/src/test/java/com/magenic/jmaqs/utilities/GenericWaitNotParallelUnitTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
  * Tests running in serial.
  */
 @Test(singleThreaded = true)
-public class GenericWaitUnitTestsNotParallel {
+public class GenericWaitNotParallelUnitTest {
   /**
    * Constant test string.
    */
@@ -47,7 +47,7 @@ public class GenericWaitUnitTestsNotParallel {
   public void passNoParamForTest() {
     initialReturnValue = false;
     try {
-      GenericWait.waitFor(GenericWaitUnitTestsNotParallel::isNotParamTest);
+      GenericWait.waitFor(GenericWaitNotParallelUnitTest::isNotParamTest);
     } catch (Exception e) {
       Assert.fail("waitFor no parameter test failed with exception", e);
     }

--- a/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceWithWrapperTest.java
+++ b/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceWithWrapperTest.java
@@ -15,7 +15,7 @@ import org.testng.annotations.Test;
 /**
  * Test with the web service wrapper directly.
  */
-public class WebServiceWithWrapper {
+public class WebServiceWithWrapperTest {
   /**
    * Verifies that basic GET features work with the HttpClientWrapper.
    * 

--- a/Framework/pom.xml
+++ b/Framework/pom.xml
@@ -12,7 +12,7 @@
 		<module>jmaqs-base</module>
 		<module>jmaqs-selenium</module>
 		<module>jmaqs-webservices</module>
-		<!--<module>jmaqs-appium</module>-->
+		<module>jmaqs-appium</module>
 	</modules>
 
 	<repositories>


### PR DESCRIPTION
In order for maven to see unit test file and use that, the filename must end in *Test* to satisfy the regexp.  This PR will allow the rest of the unit tests to execute.