### PR TITLE
JMAQS #53 - Media Type

### DIFF
--- a/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/MediaType.java
+++ b/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/MediaType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 (C) Magenic, All rights Reserved
+ */
+
+package com.magenic.jmaqs.webservices;
+
+/**
+ * The enum Media type.
+ */
+public enum MediaType {
+  /**
+   * App json media type.
+   */
+  APP_JSON("application/json"),
+  /**
+   * App xml media type.
+   */
+  APP_XML("application/xml"),
+  /**
+   * Plain text media type.
+   */
+  PLAIN_TEXT("text/plain"),
+  /**
+   * Image png media type.
+   */
+  IMAGE_PNG("image/png");
+
+  /**
+   * Getter for property 'mediaTypeString'.
+   *
+   * @return Value for property 'mediaTypeString'.
+   */
+  public String getMediaTypeString() {
+    return mediaTypeString;
+  }
+
+  /**
+   * The Media type.
+   */
+  private final String mediaTypeString;
+
+  MediaType(String string) {
+    this.mediaTypeString = string;
+  }
+
+  @Override
+  public String toString() {
+    //HACK: This is an attempt to avoid calling for the string explicitly.  Review when necessary
+    return mediaTypeString;
+  }
+}

--- a/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/MediaTypeTest.java
+++ b/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/MediaTypeTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 (C) Magenic, All rights Reserved
+ */
+
+package com.magenic.jmaqs.webservices;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class MediaTypeTest {
+
+  @Test
+  public void testTestToStringAppJson() {
+    Assert.assertEquals(MediaType.APP_JSON.toString(), MediaType.APP_JSON.getMediaTypeString());
+  }
+
+  @Test
+  public void testTestToStringAppXml() {
+    Assert.assertEquals(MediaType.APP_XML.toString(), MediaType.APP_XML.getMediaTypeString());
+  }
+
+  @Test
+  public void testTestToStringPlainText() {
+    Assert.assertEquals(MediaType.PLAIN_TEXT.toString(), MediaType.PLAIN_TEXT.getMediaTypeString());
+  }
+
+  @Test
+  public void testTestToStringImagePng() {
+    Assert.assertEquals(MediaType.IMAGE_PNG.toString(), MediaType.IMAGE_PNG.getMediaTypeString());
+  }
+
+}

--- a/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/MediaTypeTest.java
+++ b/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/MediaTypeTest.java
@@ -7,8 +7,6 @@ package com.magenic.jmaqs.webservices;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
-
 public class MediaTypeTest {
 
   @Test


### PR DESCRIPTION
MediaType - 0h 18m - Enum values and unit tests for logic… completed.

Module [JMAQS]:
  + MediaType.java
  + MediaTypeTest.java

Closes #53.