### PR TITLE
Update HttpClientWrapper to WebServiceDriver

### DIFF
--- a/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/BaseWebServiceTest.java
+++ b/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/BaseWebServiceTest.java
@@ -5,7 +5,6 @@
 package com.magenic.jmaqs.webservices;
 
 import com.magenic.jmaqs.base.BaseExtendableTest;
-import com.magenic.jmaqs.base.BaseTest;
 
 import com.magenic.jmaqs.utilities.logging.Logger;
 import java.net.URISyntaxException;
@@ -22,12 +21,12 @@ public class BaseWebServiceTest extends BaseExtendableTest<WebServiceTestObject>
   private ThreadLocal<WebServiceTestObject> webServiceTestObject = new ThreadLocal<WebServiceTestObject>();
 
   /**
-   * Get HttpClientWrapper.
+   * Get the Web Service Driver.
    * 
    * @return WebDriver
    */
-  public HttpClientWrapper getHttpClientWrapper() {
-    return this.webServiceTestObject.get().webServiceWrapper;
+  public WebServiceDriver getWebServiceDriver() {
+    return this.webServiceTestObject.get().getWebServiceDriver();
   }
 
   /**
@@ -47,7 +46,7 @@ public class BaseWebServiceTest extends BaseExtendableTest<WebServiceTestObject>
   @Override
   protected void postSetupLogging() throws Exception {
 
-    HttpClientWrapper wrapper = new HttpClientWrapper(WebServiceConfig.getWebServiceUri());
+    WebServiceDriver wrapper = new WebServiceDriver(WebServiceConfig.getWebServiceUri());
     webServiceTestObject.set(
         new WebServiceTestObject(wrapper, this.getLogger(), this.getFullyQualifiedTestClassName()));
   }
@@ -69,7 +68,7 @@ public class BaseWebServiceTest extends BaseExtendableTest<WebServiceTestObject>
     //FIXME: Workaround to get module working.  Must Refactor.
     Logger logger = this.createLogger();
     try {
-      HttpClientWrapper httpClientWrapper = new HttpClientWrapper(WebServiceConfig.getWebServiceUri());
+      WebServiceDriver httpClientWrapper = new WebServiceDriver(WebServiceConfig.getWebServiceUri());
       WebServiceTestObject webServiceTestObject = new WebServiceTestObject(httpClientWrapper, logger, this.getFullyQualifiedTestClassName());
       this.setTestObject(webServiceTestObject);
       this.webServiceTestObject.set(webServiceTestObject);

--- a/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/BaseWebServiceTest.java
+++ b/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/BaseWebServiceTest.java
@@ -18,6 +18,7 @@ public class BaseWebServiceTest extends BaseExtendableTest<WebServiceTestObject>
   /**
    * Thread local storage of web service test object.
    */
+  @Deprecated
   private ThreadLocal<WebServiceTestObject> webServiceTestObject = new ThreadLocal<WebServiceTestObject>();
 
   /**
@@ -44,6 +45,7 @@ public class BaseWebServiceTest extends BaseExtendableTest<WebServiceTestObject>
    * @see com.magenic.jmaqs.utilities.BaseTest.BaseTest#postSetupLogging()
    */
   @Override
+  @Deprecated
   protected void postSetupLogging() throws Exception {
 
     WebServiceDriver wrapper = new WebServiceDriver(WebServiceConfig.getWebServiceUri());

--- a/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/WebServiceDriver.java
+++ b/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/WebServiceDriver.java
@@ -29,7 +29,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
 
 /**
- * The HTTP client wrapper.
+ * The Web Service Driver.
  */
 public class WebServiceDriver {
   /**
@@ -66,7 +66,7 @@ public class WebServiceDriver {
   }
 
   /**
-   * Constructor that sets the http Client.
+   * Class Constructor that sets the http Client.
    * @param newHttpClient the http client to be set.
    */
   public WebServiceDriver(CloseableHttpClient newHttpClient) {
@@ -108,7 +108,7 @@ public class WebServiceDriver {
   }
 
   /**
-   * Sets the base Web Service address for the HttpClientWrapper.
+   * Sets the base Web Service address for the Web Service Driver.
    * 
    * @param address
    *          The string to set the URI to

--- a/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/WebServiceDriver.java
+++ b/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/WebServiceDriver.java
@@ -61,7 +61,6 @@ public class WebServiceDriver {
    *          The base URI address to use
    */
   public WebServiceDriver(URI baseAddress) {
-
     this.baseAddress = baseAddress;
   }
 

--- a/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/WebServiceDriver.java
+++ b/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/WebServiceDriver.java
@@ -31,8 +31,7 @@ import org.apache.http.message.BasicHeader;
 /**
  * The HTTP client wrapper.
  */
-public class HttpClientWrapper {
-
+public class WebServiceDriver {
   /**
    * The base HTTP client control.
    */
@@ -51,7 +50,7 @@ public class HttpClientWrapper {
    * @throws URISyntaxException
    *           URI syntax is invalid
    */
-  public HttpClientWrapper(String baseAddress) throws URISyntaxException {
+  public WebServiceDriver(String baseAddress) throws URISyntaxException {
     this(new URI(baseAddress));
   }
 
@@ -61,9 +60,17 @@ public class HttpClientWrapper {
    * @param baseAddress
    *          The base URI address to use
    */
-  public HttpClientWrapper(URI baseAddress) {
+  public WebServiceDriver(URI baseAddress) {
 
     this.baseAddress = baseAddress;
+  }
+
+  /**
+   * Constructor that sets the http Client.
+   * @param newHttpClient the http client to be set.
+   */
+  public WebServiceDriver(CloseableHttpClient newHttpClient) {
+    this.baseHttpClient = newHttpClient;
   }
 
   /**
@@ -344,13 +351,13 @@ public class HttpClientWrapper {
 
   /**
    * Ensure the response returned a success code.
-   * 
+   *
    * @param response
    *          And HTTP response
-   * @throws Exception
-   *           If the response was null or returned with an error code
+   * @throws Exception If the response was null or returned with an error code
    */
-  private static void ensureSuccessStatusCode(HttpResponse response) throws Exception {
+  private static void ensureSuccessStatusCode(final HttpResponse response)
+          throws Exception {
     // Make sure a response was returned
     if (response == null) {
       throw new NullPointerException("Response was null");

--- a/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/WebServiceTestObject.java
+++ b/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/WebServiceTestObject.java
@@ -23,8 +23,8 @@ public class WebServiceTestObject extends BaseTestObject {
    * @param logger The Logger Object.
    * @param fullyQualifiedTestName The fully qualified test name.
    */
-  public WebServiceTestObject(final WebServiceDriver newWebServiceDriver,
-                    final Logger logger, final String fullyQualifiedTestName) {
+  public WebServiceTestObject(WebServiceDriver newWebServiceDriver,
+                    Logger logger, String fullyQualifiedTestName) {
     super(logger, fullyQualifiedTestName);
     this.webServiceDriver = newWebServiceDriver;
   }
@@ -41,7 +41,7 @@ public class WebServiceTestObject extends BaseTestObject {
    * Set the web service wrapper for the WebServiceTestObject.
    * @param newWebServiceDriver The web service driver
    */
-  public void setWebServiceDriver(final WebServiceDriver newWebServiceDriver) {
+  public void setWebServiceDriver(WebServiceDriver newWebServiceDriver) {
     this.webServiceDriver = newWebServiceDriver;
   }
 

--- a/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/WebServiceTestObject.java
+++ b/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/WebServiceTestObject.java
@@ -13,42 +13,36 @@ import com.magenic.jmaqs.utilities.logging.Logger;
 public class WebServiceTestObject extends BaseTestObject {
 
   /**
-   * The HTTP client wrapper.
+   * The Web Service Driver.
    */
-  protected HttpClientWrapper webServiceWrapper;
+  private WebServiceDriver webServiceDriver;
   
   /**
    * Initializes a new instance of the WebServiceTestObject.
-   * 
-   * @param webServiceWrapper
-   *          The web service wrapper
-   * @param logger
-   *          The Logger Object
-   * @param fullyQualifiedTestName
-   *          The fully qualified test name
+   * @param newWebServiceDriver The web service driver.
+   * @param logger The Logger Object.
+   * @param fullyQualifiedTestName The fully qualified test name.
    */
-  public WebServiceTestObject(HttpClientWrapper webServiceWrapper, Logger logger, String fullyQualifiedTestName) {
+  public WebServiceTestObject(final WebServiceDriver newWebServiceDriver,
+                    final Logger logger, final String fullyQualifiedTestName) {
     super(logger, fullyQualifiedTestName);
-    this.webServiceWrapper = webServiceWrapper;
+    this.webServiceDriver = newWebServiceDriver;
   }
   
   /**
    * Get the web service wrapper for the WebServiceTestObject.
-   * 
-   * @return A web service wrapper object
+   * @return A web service driver
    */
-  public HttpClientWrapper getWebServiceWrapper() {
-    return this.webServiceWrapper;
+  public WebServiceDriver getWebServiceDriver() {
+    return this.webServiceDriver;
   }
 
   /**
    * Set the web service wrapper for the WebServiceTestObject.
-   * 
-   * @param webServiceWrapper
-   *          The web service wrapper object
+   * @param newWebServiceDriver The web service driver
    */
-  public void setWebServiceWrapper(HttpClientWrapper webServiceWrapper) {
-    this.webServiceWrapper = webServiceWrapper;
+  public void setWebServiceDriver(final WebServiceDriver newWebServiceDriver) {
+    this.webServiceDriver = newWebServiceDriver;
   }
 
 }

--- a/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceDriverUnitTest.java
+++ b/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceDriverUnitTest.java
@@ -4,8 +4,15 @@
 
 package com.magenic.jmaqs.webservices;
 
+import com.magenic.jmaqs.utilities.helper.TestCategories;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -17,7 +24,7 @@ public class WebServiceDriverUnitTest {
    * Verifies that basic GET features work with the WebServiceDriver.
    * @throws Exception Web service get failed
    */
-  @Test
+  @Test(groups = TestCategories.WebService)
   public void webServiceGetVerificationTest() throws Exception {
     WebServiceDriver client = new WebServiceDriver("http://magenicautomation.azurewebsites.net");
     CloseableHttpResponse response = client.getContent("/api/String/1", ContentType.TEXT_PLAIN,
@@ -26,5 +33,57 @@ public class WebServiceDriverUnitTest {
 
     Assert.assertTrue(responseString.contains("Tomato Soup"),
         "Was expecting a result with Tomato Soup but instead got - " + response.toString());
+  }
+
+  /**
+   * Verifies that basic GET features work with the WebServiceDriver.
+   * @throws Exception Web service get failed
+   */
+  @Test(groups = TestCategories.WebService)
+  public void setWebServiceAddress() throws Exception {
+    WebServiceDriver webServiceDriver = new WebServiceDriver("http://magenicautomation.azurewebsites.net");
+
+    webServiceDriver.setBaseWebServiceAddress("http://magenicautomation.azurewebsites.net");
+    Assert.assertEquals(webServiceDriver.getBaseWebServiceAddress().toString(),
+            "http://magenicautomation.azurewebsites.net", "Addresses don't match");
+  }
+
+  /**
+   * Verifies that basic GET features work with the WebServiceDriver.
+   */
+  @Test(groups = TestCategories.WebService)
+  public void setHttpClient() {
+    CloseableHttpClient httpClient = new CloseableHttpClient() {
+      /**
+       * @deprecated
+       */
+      @Override
+      public HttpParams getParams() {
+        return null;
+      }
+
+      /**
+       * @deprecated
+       */
+      @Override
+      public ClientConnectionManager getConnectionManager() {
+        return null;
+      }
+
+      @Override
+      public void close() { }
+
+      @Override
+      protected CloseableHttpResponse doExecute(HttpHost httpHost,
+              HttpRequest httpRequest, HttpContext httpContext) {
+        return null;
+      }
+    };
+
+    WebServiceDriver webServiceDriver = new WebServiceDriver(httpClient);
+
+    webServiceDriver.setHttpClient(httpClient);
+    Assert.assertNotNull(webServiceDriver.getHttpClient(MediaType.APP_JSON.toString()),
+           "The http Client is null");
   }
 }

--- a/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceDriverUnitTest.java
+++ b/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceDriverUnitTest.java
@@ -4,27 +4,22 @@
 
 package com.magenic.jmaqs.webservices;
 
-import com.magenic.jmaqs.webservices.HttpClientWrapper;
-import com.magenic.jmaqs.webservices.WebServiceUtils;
-
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.entity.ContentType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
- * Test with the web service wrapper directly.
+ * Test with the web service driver directly.
  */
-public class WebServiceWithWrapperTest {
+public class WebServiceDriverUnitTest {
   /**
-   * Verifies that basic GET features work with the HttpClientWrapper.
-   * 
-   * @throws Exception
-   *           Web service get failed
+   * Verifies that basic GET features work with the WebServiceDriver.
+   * @throws Exception Web service get failed
    */
   @Test
   public void webServiceGetVerificationTest() throws Exception {
-    HttpClientWrapper client = new HttpClientWrapper("http://magenicautomation.azurewebsites.net");
+    WebServiceDriver client = new WebServiceDriver("http://magenicautomation.azurewebsites.net");
     CloseableHttpResponse response = client.getContent("/api/String/1", ContentType.TEXT_PLAIN,
         true);
     String responseString = WebServiceUtils.getResponseBody(response);

--- a/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceDriverUnitTest.java
+++ b/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceDriverUnitTest.java
@@ -16,6 +16,8 @@ import org.apache.http.protocol.HttpContext;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.net.URISyntaxException;
+
 /**
  * Test with the web service driver directly.
  */
@@ -52,38 +54,16 @@ public class WebServiceDriverUnitTest {
    * Verifies that basic GET features work with the WebServiceDriver.
    */
   @Test(groups = TestCategories.WebService)
-  public void setHttpClient() {
-    CloseableHttpClient httpClient = new CloseableHttpClient() {
-      /**
-       * @deprecated
-       */
-      @Override
-      public HttpParams getParams() {
-        return null;
-      }
-
-      /**
-       * @deprecated
-       */
-      @Override
-      public ClientConnectionManager getConnectionManager() {
-        return null;
-      }
-
-      @Override
-      public void close() { }
-
-      @Override
-      protected CloseableHttpResponse doExecute(HttpHost httpHost,
-              HttpRequest httpRequest, HttpContext httpContext) {
-        return null;
-      }
-    };
-
-    WebServiceDriver webServiceDriver = new WebServiceDriver(httpClient);
-
-    webServiceDriver.setHttpClient(httpClient);
-    Assert.assertNotNull(webServiceDriver.getHttpClient(MediaType.APP_JSON.toString()),
-           "The http Client is null");
+  public void setHttpClient() throws URISyntaxException {
+    WebServiceDriver webServiceDriver1 = new WebServiceDriver(
+            "http://magenicautomation.azurewebsites.net");
+    webServiceDriver1.setHttpClient(webServiceDriver1.getHttpClient(
+            MediaType.APP_JSON.toString()));
+    WebServiceDriver webServiceDriver2 = new WebServiceDriver(
+            webServiceDriver1.getHttpClient(
+                    MediaType.APP_XML.toString()));
+    Assert.assertNotNull(webServiceDriver1.getHttpClient(
+            MediaType.APP_JSON.toString()), "Driver 1 is null");
+    Assert.assertNotNull(webServiceDriver2, "Driver 2 is null");
   }
 }

--- a/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceUnitTest.java
+++ b/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceUnitTest.java
@@ -27,7 +27,7 @@ public class WebServiceUnitTest extends BaseWebServiceTest {
   @Test
   public void webServiceGetVerificationTest() throws Exception {
 
-    CloseableHttpResponse response = this.getHttpClientWrapper().getContent("/api/String/1",
+    CloseableHttpResponse response = this.getWebServiceDriver().getContent("/api/String/1",
         ContentType.TEXT_PLAIN, true);
     String responseString = WebServiceUtils.getResponseBody(response);
 
@@ -44,7 +44,7 @@ public class WebServiceUnitTest extends BaseWebServiceTest {
   @Test
   public void webServiceGetError() throws Exception {
 
-    CloseableHttpResponse response = this.getHttpClientWrapper().getContent("/api/String/-1",
+    CloseableHttpResponse response = this.getWebServiceDriver().getContent("/api/String/-1",
         ContentType.TEXT_PLAIN, false);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), 204);
   }
@@ -58,7 +58,7 @@ public class WebServiceUnitTest extends BaseWebServiceTest {
   @Test
   public void webServiceDelete() throws Exception {
 
-    CloseableHttpResponse response = this.getHttpClientWrapper()
+    CloseableHttpResponse response = this.getWebServiceDriver()
         .deleteContent("/api/XML_JSON/Delete/1", ContentType.TEXT_PLAIN, false);
     Assert.assertEquals(response.getStatusLine().getStatusCode(), 200);
   }
@@ -72,7 +72,7 @@ public class WebServiceUnitTest extends BaseWebServiceTest {
   @Test
   public void webServicePatchError() throws Exception {
     HttpEntity content = WebServiceUtils.createEntity("", ContentType.APPLICATION_XML);
-    CloseableHttpResponse response = this.getHttpClientWrapper().patchContent("/api/XML_JSON/Put/1",
+    CloseableHttpResponse response = this.getWebServiceDriver().patchContent("/api/XML_JSON/Put/1",
         content, ContentType.APPLICATION_XML, false);
 
     Assert.assertEquals(response.getStatusLine().getStatusCode(), 405);
@@ -88,7 +88,7 @@ public class WebServiceUnitTest extends BaseWebServiceTest {
   @Test
   public void webServicePostError() throws Exception {
     HttpEntity content = WebServiceUtils.createEntity("", ContentType.TEXT_PLAIN);
-    CloseableHttpResponse response = this.getHttpClientWrapper().postContent("/api/String", content,
+    CloseableHttpResponse response = this.getWebServiceDriver().postContent("/api/String", content,
         ContentType.TEXT_PLAIN, false);
 
     Assert.assertEquals(response.getStatusLine().getStatusCode(), 400);
@@ -104,7 +104,7 @@ public class WebServiceUnitTest extends BaseWebServiceTest {
   @Test
   public void webServicePutError() throws Exception {
     HttpEntity content = WebServiceUtils.createEntity("", ContentType.APPLICATION_XML);
-    CloseableHttpResponse response = this.getHttpClientWrapper().putContent("/api/XML_JSON/Put/1",
+    CloseableHttpResponse response = this.getWebServiceDriver().putContent("/api/XML_JSON/Put/1",
         content, ContentType.APPLICATION_XML, false);
 
     Assert.assertEquals(response.getStatusLine().getStatusCode(), 409);

--- a/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceUnitTest.java
+++ b/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceUnitTest.java
@@ -4,8 +4,7 @@
 
 package com.magenic.jmaqs.webservices;
 
-import com.magenic.jmaqs.webservices.BaseWebServiceTest;
-import com.magenic.jmaqs.webservices.WebServiceUtils;
+import com.magenic.jmaqs.utilities.helper.TestCategories;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -24,7 +23,7 @@ public class WebServiceUnitTest extends BaseWebServiceTest {
    * @throws Exception
    *           There was a problem with the test
    */
-  @Test
+  @Test(groups = TestCategories.WebService)
   public void webServiceGetVerificationTest() throws Exception {
 
     CloseableHttpResponse response = this.getWebServiceDriver().getContent("/api/String/1",
@@ -41,7 +40,7 @@ public class WebServiceUnitTest extends BaseWebServiceTest {
    * @throws Exception
    *           There was a problem with the test
    */
-  @Test
+  @Test(groups = TestCategories.WebService)
   public void webServiceGetError() throws Exception {
 
     CloseableHttpResponse response = this.getWebServiceDriver().getContent("/api/String/-1",
@@ -55,7 +54,7 @@ public class WebServiceUnitTest extends BaseWebServiceTest {
    * @throws Exception
    *           There was a problem with the test
    */
-  @Test
+  @Test(groups = TestCategories.WebService)
   public void webServiceDelete() throws Exception {
 
     CloseableHttpResponse response = this.getWebServiceDriver()
@@ -69,7 +68,7 @@ public class WebServiceUnitTest extends BaseWebServiceTest {
    * @throws Exception
    *           There was a problem with the test
    */
-  @Test
+  @Test(groups = TestCategories.WebService)
   public void webServicePatchError() throws Exception {
     HttpEntity content = WebServiceUtils.createEntity("", ContentType.APPLICATION_XML);
     CloseableHttpResponse response = this.getWebServiceDriver().patchContent("/api/XML_JSON/Put/1",
@@ -85,7 +84,7 @@ public class WebServiceUnitTest extends BaseWebServiceTest {
    * @throws Exception
    *           There was a problem with the test
    */
-  @Test
+  @Test(groups = TestCategories.WebService)
   public void webServicePostError() throws Exception {
     HttpEntity content = WebServiceUtils.createEntity("", ContentType.TEXT_PLAIN);
     CloseableHttpResponse response = this.getWebServiceDriver().postContent("/api/String", content,
@@ -101,7 +100,7 @@ public class WebServiceUnitTest extends BaseWebServiceTest {
    * @throws Exception
    *           There was a problem with the test
    */
-  @Test
+  @Test(groups = TestCategories.WebService)
   public void webServicePutError() throws Exception {
     HttpEntity content = WebServiceUtils.createEntity("", ContentType.APPLICATION_XML);
     CloseableHttpResponse response = this.getWebServiceDriver().putContent("/api/XML_JSON/Put/1",


### PR DESCRIPTION
Renamed HttpClientWrapper to WebServiceDriver.
Renamed WebServiceWithWrapperTest to WebServiceDriverUnitTest.
Updated classes to use WebServiceDriver.
Updated Tests to use WebServiceDriver.

This closes #116.