### PR TITLE
JMAQS #170 - Remove PostSetupLogging

### DIFF
--- a/Framework/jmaqs-appium/src/test/java/com/magenic/jmaqs/appium/AppiumUtilitiesUnitTest.java
+++ b/Framework/jmaqs-appium/src/test/java/com/magenic/jmaqs/appium/AppiumUtilitiesUnitTest.java
@@ -207,10 +207,6 @@ public class AppiumUtilitiesUnitTest extends BaseTest {
     Assert.assertNull(appiumDriver.getSessionId(), "Expected Appium Driver Session ID to be null.");
   }
 
-  @Override protected void postSetupLogging() throws Exception {
-
-  }
-
   @Override protected void beforeLoggingTeardown(ITestResult resultType) {
 
   }

--- a/Framework/jmaqs-appium/src/test/java/com/magenic/jmaqs/appium/BaseAppiumTestUnitTest.java
+++ b/Framework/jmaqs-appium/src/test/java/com/magenic/jmaqs/appium/BaseAppiumTestUnitTest.java
@@ -51,8 +51,4 @@ public class BaseAppiumTestUnitTest extends BaseAppiumTest {
         "Checking that Appium Driver is not null through BaseAppiumTest");
   }
 
-  @Override
-  protected void postSetupLogging() throws Exception {
-
-  }
 }

--- a/Framework/jmaqs-appium/src/test/java/com/magenic/jmaqs/appium/MobileDriverManagerUnitTest.java
+++ b/Framework/jmaqs-appium/src/test/java/com/magenic/jmaqs/appium/MobileDriverManagerUnitTest.java
@@ -62,11 +62,6 @@ public class MobileDriverManagerUnitTest extends BaseTest {
   }
 
   @Override
-  protected void postSetupLogging() throws Exception {
-
-  }
-
-  @Override
   protected void beforeLoggingTeardown(ITestResult resultType) {
 
   }

--- a/Framework/jmaqs-base/src/main/java/com/magenic/jmaqs/base/BaseTest.java
+++ b/Framework/jmaqs-base/src/main/java/com/magenic/jmaqs/base/BaseTest.java
@@ -289,13 +289,6 @@ public abstract class BaseTest {
   }
 
   /**
-   * Overload function for doing post setup logging.
-   * @deprecated methodology no longer used.
-   */
-  @Deprecated
-  protected abstract void postSetupLogging() throws Exception;
-
-  /**
    * Steps to do before logging teardown results.
    *
    * @param resultType The test result

--- a/Framework/jmaqs-base/src/test/java/com/magenic/jmaqs/base/BaseTestObjectTest.java
+++ b/Framework/jmaqs-base/src/test/java/com/magenic/jmaqs/base/BaseTestObjectTest.java
@@ -4,9 +4,6 @@
 
 package com.magenic.jmaqs.base;
 
-import com.magenic.jmaqs.base.BaseTest;
-import com.magenic.jmaqs.base.BaseTestObject;
-import com.magenic.jmaqs.base.DriverManager;
 import com.magenic.jmaqs.utilities.logging.Logger;
 import com.magenic.jmaqs.utilities.performance.PerfTimerCollection;
 
@@ -329,14 +326,6 @@ public class BaseTestObjectTest extends BaseTest {
       }
     };
   }*/
-
-  /**
-   * Overload function for doing post setup logging.
-   */
-  @Override
-  protected void postSetupLogging() throws Exception {
-
-  }
 
   /**
    * Steps to do before logging teardown results.

--- a/Framework/jmaqs-base/src/test/java/com/magenic/jmaqs/base/BaseTestUnitTest.java
+++ b/Framework/jmaqs-base/src/test/java/com/magenic/jmaqs/base/BaseTestUnitTest.java
@@ -100,16 +100,6 @@ public class BaseTestUnitTest extends BaseTest {
   /*
    * (non-Javadoc)
    *
-   * @see com.magenic.jmaqs.utilities.BaseTest.BaseTest#postSetupLogging()
-   */
-  @Override
-  protected void postSetupLogging() {
-
-  }
-
-  /*
-   * (non-Javadoc)
-   *
    * @see com.magenic.jmaqs.utilities.BaseTest.BaseTest#beforeLoggingTeardown(org.testng.
    * ITestResult)
    */

--- a/Framework/jmaqs-base/src/test/java/com/magenic/jmaqs/base/ManagerDictionaryUnitTest.java
+++ b/Framework/jmaqs-base/src/test/java/com/magenic/jmaqs/base/ManagerDictionaryUnitTest.java
@@ -6,10 +6,6 @@ package com.magenic.jmaqs.base;
 
 import static org.testng.Assert.assertNotNull;
 
-import com.magenic.jmaqs.base.BaseTest;
-import com.magenic.jmaqs.base.BaseTestObject;
-import com.magenic.jmaqs.base.DriverManager;
-import com.magenic.jmaqs.base.ManagerDictionary;
 import java.util.function.Supplier;
 import org.testng.Assert;
 import org.testng.ITestResult;
@@ -96,11 +92,6 @@ public class ManagerDictionaryUnitTest extends BaseTest {
     Assert.assertTrue(managerDictionary.remove(dm2),"Checking if remove reported as successful");
     Assert.assertTrue(managerDictionary.containsKey(dm1));
     Assert.assertFalse(managerDictionary.containsKey(dm2));
-  }
-
-  @Override
-  protected void postSetupLogging() throws Exception {
-
   }
 
   @Override

--- a/Framework/jmaqs-database/src/test/java/com/magenic/jmaqs/database/DatabaseConfigUnitTest.java
+++ b/Framework/jmaqs-database/src/test/java/com/magenic/jmaqs/database/DatabaseConfigUnitTest.java
@@ -4,7 +4,6 @@
 
 package com.magenic.jmaqs.database;
 
-import com.magenic.jmaqs.base.BaseGenericTest;
 import com.magenic.jmaqs.base.BaseTest;
 import com.magenic.jmaqs.utilities.helper.TestCategories;
 import org.testng.Assert;
@@ -38,11 +37,6 @@ public class DatabaseConfigUnitTest extends BaseTest {
   @Test
   public void testGetEntityDirectoryString() {
     Assert.assertEquals(DatabaseConfig.getEntityDirectoryString(), "./src/test/java/entities");
-  }
-
-  @Override
-  protected void postSetupLogging() throws Exception {
-
   }
 
   @Override

--- a/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/ActionBuilderUnitTest.java
+++ b/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/ActionBuilderUnitTest.java
@@ -114,8 +114,4 @@ public class ActionBuilderUnitTest extends BaseSeleniumTest {
     UIWaitFactory.getWaitDriver(this.getWebDriver()).waitForPageLoad();
   }
 
-  @Override
-  protected void postSetupLogging() throws Exception {
-
-  }
 }

--- a/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/BaseSeleniumTestUnitTest.java
+++ b/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/BaseSeleniumTestUnitTest.java
@@ -47,8 +47,4 @@ public class BaseSeleniumTestUnitTest extends BaseSeleniumTest {
     }
   }
 
-  @Override
-  protected void postSetupLogging() throws Exception {
-
-  }
 }

--- a/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/ElementHandlerUnitTest.java
+++ b/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/ElementHandlerUnitTest.java
@@ -359,8 +359,4 @@ public class ElementHandlerUnitTest extends BaseSeleniumTest {
     UIWaitFactory.getWaitDriver(getWebDriver()).waitForPageLoad();
   }
 
-  @Override
-  protected void postSetupLogging() throws Exception {
-
-  }
 }

--- a/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/EventHandlerUnitTest.java
+++ b/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/EventHandlerUnitTest.java
@@ -453,9 +453,5 @@ public class EventHandlerUnitTest extends BaseSeleniumTest {
     return text;
   }
 
-  @Override
-  protected void postSetupLogging() throws Exception {
-
-  }
 }
 

--- a/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/FluentWaitFactoryUnitTest.java
+++ b/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/FluentWaitFactoryUnitTest.java
@@ -52,8 +52,4 @@ public class FluentWaitFactoryUnitTest extends BaseSeleniumTest {
     Assert.assertNotNull(fluentWait, String.format(assertNotNullErrorTemplate, "fluentWait"));
   }
 
-  @Override
-  protected void postSetupLogging() throws Exception {
-
-  }
 }

--- a/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/SeleniumDriverManagerUnitTest.java
+++ b/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/SeleniumDriverManagerUnitTest.java
@@ -88,11 +88,6 @@ public class SeleniumDriverManagerUnitTest extends BaseTest {
   }
 
   @Override
-  protected void postSetupLogging() throws Exception {
-
-  }
-
-  @Override
   protected void beforeLoggingTeardown(ITestResult resultType) {
 
   }

--- a/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/SeleniumUtilitiesUnitTest.java
+++ b/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/SeleniumUtilitiesUnitTest.java
@@ -275,11 +275,6 @@ public class SeleniumUtilitiesUnitTest extends BaseTest {
   }
 
   @Override
-  protected void postSetupLogging() throws Exception {
-
-  }
-
-  @Override
   protected void beforeLoggingTeardown(ITestResult resultType) {
 
   }

--- a/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/UIFindFactoryUnitTest.java
+++ b/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/UIFindFactoryUnitTest.java
@@ -60,8 +60,4 @@ public class UIFindFactoryUnitTest extends BaseSeleniumTest {
         String.format(assertNotNullErrorTemplate, "findWithWebDriver"));
   }
 
-  @Override
-  protected void postSetupLogging() throws Exception {
-
-  }
 }

--- a/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/UIWaitFactoryUnitTest.java
+++ b/Framework/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/UIWaitFactoryUnitTest.java
@@ -122,8 +122,4 @@ public class UIWaitFactoryUnitTest extends BaseSeleniumTest {
         String.format(assertNotEqualErrorTemplate, "waitDriverToBeRemoved", "newWaitDriver"));
   }
 
-  @Override
-  protected void postSetupLogging() throws Exception {
-
-  }
 }

--- a/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/BaseWebServiceTest.java
+++ b/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/BaseWebServiceTest.java
@@ -19,27 +19,12 @@ import org.testng.ITestResult;
 public abstract class BaseWebServiceTest extends BaseExtendableTest<WebServiceTestObject> {
 
   /**
-   * Thread local storage of web service test object.
-   */
-  @Deprecated private ThreadLocal<WebServiceTestObject> webServiceTestObject = new ThreadLocal<WebServiceTestObject>();
-
-  /**
    * Get the Web Service Driver.
    *
    * @return WebServiceDriver
    */
   public WebServiceDriver getWebServiceDriver() {
     return this.getTestObject().getWebServiceDriver();
-  }
-
-  /**
-   * Get the webServiceTestObject for this test.
-   *
-   * @return The seleniumTestObject
-   */
-  @Deprecated public WebServiceTestObject getWebServiceTestObject() {
-    return this.webServiceTestObject.get();
-
   }
 
   /**

--- a/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/BaseWebServiceTest.java
+++ b/Framework/jmaqs-webservices/src/main/java/com/magenic/jmaqs/webservices/BaseWebServiceTest.java
@@ -54,18 +54,6 @@ public abstract class BaseWebServiceTest extends BaseExtendableTest<WebServiceTe
   /*
    * (non-Javadoc)
    *
-   * @see com.magenic.jmaqs.utilities.BaseTest.BaseTest#postSetupLogging()
-   */
-  @Override @Deprecated protected void postSetupLogging() throws Exception {
-
-    WebServiceDriver wrapper = new WebServiceDriver(WebServiceConfig.getWebServiceUri());
-    webServiceTestObject.set(
-        new WebServiceTestObject(wrapper, this.getLogger(), this.getFullyQualifiedTestClassName()));
-  }
-
-  /*
-   * (non-Javadoc)
-   *
    * @see com.magenic.jmaqs.utilities.BaseTest.BaseTest# beforeLoggingTeardown
    * (org.testng.ITestResult)
    */

--- a/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceDriverManagerUnitTest.java
+++ b/Framework/jmaqs-webservices/src/test/java/com/magenic/jmaqs/webservices/WebServiceDriverManagerUnitTest.java
@@ -90,10 +90,6 @@ public class WebServiceDriverManagerUnitTest extends BaseTest {
     Assert.assertNull(driverManager.getBaseDriver(), "Expected Base Driver to be null.");
   }
 
-  @Override protected void postSetupLogging() throws Exception {
-
-  }
-
   @Override protected void beforeLoggingTeardown(ITestResult resultType) {
 
   }


### PR DESCRIPTION
Remove the deprecated abstract base module method. Closes #170 