### PR TITLE
JMAQS #172 - Clean Up Utilities tests properly

### DIFF
--- a/Framework/jmaqs-utilities/src/test/java/com/magenic/jmaqs/utilities/FileLoggerUnitTest.java
+++ b/Framework/jmaqs-utilities/src/test/java/com/magenic/jmaqs/utilities/FileLoggerUnitTest.java
@@ -4,8 +4,8 @@
 
 package com.magenic.jmaqs.utilities;
 
+import com.magenic.jmaqs.utilities.helper.Config;
 import com.magenic.jmaqs.utilities.helper.StringProcessor;
-
 
 import java.io.File;
 import java.io.IOException;
@@ -25,15 +25,20 @@ import org.testng.asserts.SoftAssert;
  */
 @Test(singleThreaded = true)
 public class FileLoggerUnitTest {
+
+  public static final String LOG_FOLDER_MESSAGING_LEVEL_DIRECTORY =
+      LoggingConfig.getLogDirectory() + "/" + "Log Folder Messaging Level Directory";
+
   @DataProvider(name = "logLevels")
   public static Object[][] data() {
-    return new Object[][] {
-      { "VERBOSE", new HashMap<String, Boolean>() {{
-          put("VERBOSE", true); put("INFORMATION", true); put("GENERIC", true);
-          put("SUCCESS", true); put("WARNING", true); put("ERROR", true);
-        }}
-      },
-      { "INFORMATION", new HashMap<String, Boolean>() {{
+    return new Object[][] { { "VERBOSE", new HashMap<String, Boolean>() {{
+      put("VERBOSE", true);
+      put("INFORMATION", true);
+      put("GENERIC", true);
+      put("SUCCESS", true);
+      put("WARNING", true);
+      put("ERROR", true);
+    }} }, { "INFORMATION", new HashMap<String, Boolean>() {{
           put("VERBOSE", false); put("INFORMATION", true); put("GENERIC", true);
           put("SUCCESS", true); put("WARNING", true); put("ERROR", true);
         }}
@@ -284,10 +289,13 @@ public class FileLoggerUnitTest {
    */
   @Test
   public void FileLoggerCatchThrownException() {
-    FileLogger logger = new FileLogger(true, "", "FileLoggerCatchThrownException", MessageType.GENERIC);
+    FileLogger logger = new FileLogger(true, "", "FileLoggerCatchThrownException",
+        MessageType.GENERIC);
     logger.setFilePath("<>");
 
     logger.logMessage(MessageType.GENERIC, "test throws error");
+    File file = new File(logger.getFilePath());
+    file.delete();
   }
 
   /**
@@ -399,13 +407,16 @@ public class FileLoggerUnitTest {
    */
   @Test
   public void FileLoggerAppendLogFolder() {
-    FileLogger logger = new FileLogger("Append File Directory", true);
+    final String append_file_directory =
+        LoggingConfig.getLogDirectory() + "/" + "Append File Directory";
+    FileLogger logger = new FileLogger(append_file_directory, true);
 
     SoftAssert softAssert = new SoftAssert();
-    softAssert.assertEquals("Append File Directory", logger.getDirectory(),
-            "Expected Directory 'Append File Directory'.");
+    softAssert.assertEquals(append_file_directory, logger.getDirectory(),
+        "Expected Directory 'Append File Directory'.");
     softAssert.assertEquals("FileLog.txt", logger.getFileName(), "Expected correct File Name.");
-    softAssert.assertEquals(MessageType.INFORMATION, logger.getMessageType(), "Expected Information Message Type.");
+    softAssert.assertEquals(MessageType.INFORMATION, logger.getMessageType(),
+        "Expected Information Message Type.");
 
     softAssert.assertAll();
 
@@ -418,13 +429,17 @@ public class FileLoggerUnitTest {
    */
   @Test
   public void FileLoggerLogFolderFileName() {
-    FileLogger logger = new FileLogger("Log Folder File Name Directory", "LogFolderFileName.txt");
+    final String log_folder_file_name_directory =
+        LoggingConfig.getLogDirectory() + "/" + "Log Folder File Name Directory";
+    FileLogger logger = new FileLogger(log_folder_file_name_directory, "LogFolderFileName.txt");
 
     SoftAssert softAssert = new SoftAssert();
-    softAssert.assertEquals("Log Folder File Name Directory", logger.getDirectory(),
-            "Expected Directory 'Log Folder File Name Directory'.");
-    softAssert.assertEquals("LogFolderFileName.txt", logger.getFileName(), "Expected correct File Name.");
-    softAssert.assertEquals(MessageType.INFORMATION, logger.getMessageType(), "Expected Information Message Type.");
+    softAssert.assertEquals(log_folder_file_name_directory, logger.getDirectory(),
+        "Expected Directory 'Log Folder File Name Directory'.");
+    softAssert
+        .assertEquals("LogFolderFileName.txt", logger.getFileName(), "Expected correct File Name.");
+    softAssert.assertEquals(MessageType.INFORMATION, logger.getMessageType(),
+        "Expected Information Message Type.");
 
     softAssert.assertAll();
 
@@ -437,11 +452,11 @@ public class FileLoggerUnitTest {
    */
   @Test
   public void FileLoggerLogFolderMessagingLevel() {
-    FileLogger logger = new FileLogger("Log Folder Messaging Level Directory", MessageType.WARNING);
+    FileLogger logger = new FileLogger(LOG_FOLDER_MESSAGING_LEVEL_DIRECTORY, MessageType.WARNING);
 
     SoftAssert softAssert = new SoftAssert();
-    softAssert.assertEquals("Log Folder Messaging Level Directory", logger.getDirectory(),
-            "Expected Directory 'Log Folder Messaging Level Directory'.");
+    softAssert.assertEquals(LOG_FOLDER_MESSAGING_LEVEL_DIRECTORY, logger.getDirectory(),
+        "Expected Directory 'Log Folder Messaging Level Directory'.");
     softAssert.assertEquals("FileLog.txt", logger.getFileName(), "Expected correct File Name.");
     softAssert.assertEquals(MessageType.WARNING, logger.getMessageType(), "Expected Warning Message Type.");
 
@@ -494,12 +509,14 @@ public class FileLoggerUnitTest {
    */
   @Test
   public void FileLoggerAppendLogFolderFileName() {
-    FileLogger logger = new FileLogger(
-            true, "AppendLogFolderFileNameDirectory", "AppendLogFolderFileName.txt");
+    final String appendLogFolderFileNameDirectory =
+        LoggingConfig.getLogDirectory() + "/" + "AppendLogFolderFileNameDirectory";
+    FileLogger logger = new FileLogger(true, appendLogFolderFileNameDirectory,
+        "AppendLogFolderFileName.txt");
 
     SoftAssert softAssert = new SoftAssert();
-    softAssert.assertEquals("AppendLogFolderFileNameDirectory", logger.getDirectory(),
-            " Expected Directory AppendLogFolderFileNameDirectory");
+    softAssert.assertEquals(appendLogFolderFileNameDirectory, logger.getDirectory(),
+        " Expected Directory AppendLogFolderFileNameDirectory");
     softAssert.assertEquals("AppendLogFolderFileName.txt", logger.getFileName(), "Expected correct File Name.");
     softAssert.assertEquals(MessageType.INFORMATION, logger.getMessageType(), "Expected Information Message Type.");
 
@@ -514,12 +531,13 @@ public class FileLoggerUnitTest {
    */
   @Test
   public void FileLoggerAppendLogFolderMessagingLevel() {
-    FileLogger logger = new FileLogger(
-            true, "AppendLogFolderFileNameDirectory", MessageType.WARNING);
+    final String appendLogFolderFileNameDirectory =
+        LoggingConfig.getLogDirectory() + "/" + "AppendLogFolderFileNameDirectory";
+    FileLogger logger = new FileLogger(true, appendLogFolderFileNameDirectory, MessageType.WARNING);
 
     SoftAssert softAssert = new SoftAssert();
-    softAssert.assertEquals("AppendLogFolderFileNameDirectory", logger.getDirectory(),
-            " Expected Directory AppendLogFolderFileNameDirectory");
+    softAssert.assertEquals(appendLogFolderFileNameDirectory, logger.getDirectory(),
+        " Expected Directory AppendLogFolderFileNameDirectory");
     softAssert.assertEquals("FileLog.txt", logger.getFileName(), "Expected correct File Name.");
     softAssert.assertEquals(MessageType.WARNING, logger.getMessageType(), "Expected Warning Message Type.");
 
@@ -555,15 +573,18 @@ public class FileLoggerUnitTest {
    */
   @Test
   public void FileLoggerLogFolderFileNameMessagingLevel() {
-    FileLogger logger = new FileLogger(
-            "LogFolderFileNameMessagingLevelDirectory", "LogFolderFileNameMessagingLevel.txt", MessageType.WARNING);
+    final String logFolderFileNameMessagingLevelDirectory =
+        LoggingConfig.getLogDirectory() + "/" + "LogFolderFileNameMessagingLevelDirectory";
+    FileLogger logger = new FileLogger(logFolderFileNameMessagingLevelDirectory,
+        "LogFolderFileNameMessagingLevel.txt", MessageType.WARNING);
 
     SoftAssert softAssert = new SoftAssert();
-    softAssert.assertEquals("LogFolderFileNameMessagingLevelDirectory", logger.getDirectory(),
-            "Expected Directory 'LogFolderFileNameMessagingLevelDirectory'");
+    softAssert.assertEquals(logFolderFileNameMessagingLevelDirectory, logger.getDirectory(),
+        "Expected Directory 'LogFolderFileNameMessagingLevelDirectory'");
     softAssert.assertEquals("LogFolderFileNameMessagingLevel.txt", logger.getFileName(),
-            "Expected correct File Name.");
-    softAssert.assertEquals(MessageType.WARNING, logger.getMessageType(), "Expected Warning Message Type.");
+        "Expected correct File Name.");
+    softAssert.assertEquals(MessageType.WARNING, logger.getMessageType(),
+        "Expected Warning Message Type.");
 
     softAssert.assertAll();
 

--- a/Framework/jmaqs-utilities/src/test/java/com/magenic/jmaqs/utilities/HtmlFileLoggerUnitTest.java
+++ b/Framework/jmaqs-utilities/src/test/java/com/magenic/jmaqs/utilities/HtmlFileLoggerUnitTest.java
@@ -148,10 +148,13 @@ public class HtmlFileLoggerUnitTest {
    */
   @Test
   public void HtmlFileLoggerCatchThrownException() {
-    HtmlFileLogger logger = new HtmlFileLogger(true, "", "HtmlFileLoggerCatchThrownException", MessageType.GENERIC);
+    HtmlFileLogger logger = new HtmlFileLogger(true, "", "HtmlFileLoggerCatchThrownException",
+        MessageType.GENERIC);
     logger.setFilePath("<>");
 
     logger.logMessage(MessageType.GENERIC, "Test throws error as expected.");
+    File file = new File(logger.getFilePath());
+    file.delete();
   }
 
   /**
@@ -263,18 +266,18 @@ public class HtmlFileLoggerUnitTest {
    */
   @Test
   public void FileLoggerAppendLogFolder() {
-    HtmlFileLogger logger = new HtmlFileLogger("Append File Directory", true);
+    final String append_file_directory_path =
+        LoggingConfig.getLogDirectory() + "/" + "Append File Directory";
+    HtmlFileLogger logger = new HtmlFileLogger(append_file_directory_path, true);
 
     SoftAssert softAssert = new SoftAssert();
-    softAssert.assertEquals("Append File Directory", logger.getDirectory(),
-            "Expected Directory 'Append File Directory'.");
+    softAssert.assertEquals(append_file_directory_path, logger.getDirectory(),
+        "Expected Directory 'Append File Directory'.");
     softAssert.assertEquals("FileLog.html", logger.getFileName(), "Expected correct File Name.");
-    softAssert.assertEquals(MessageType.INFORMATION, logger.getMessageType(), "Expected Information Message Type.");
+    softAssert.assertEquals(MessageType.INFORMATION, logger.getMessageType(),
+        "Expected Information Message Type.");
 
     softAssert.assertAll();
-
-    File file = new File(logger.getFilePath());
-    file.delete();
   }
 
   /**
@@ -282,18 +285,20 @@ public class HtmlFileLoggerUnitTest {
    */
   @Test
   public void FileLoggerLogFolderFileName() {
-    HtmlFileLogger logger = new HtmlFileLogger("Log Folder File Name Directory", "LogFolderFileName.html");
+    final String log_folder_file_name_directory =
+        LoggingConfig.getLogDirectory() + "/" + "Log Folder File Name Directory";
+    HtmlFileLogger logger = new HtmlFileLogger(log_folder_file_name_directory,
+        "LogFolderFileName.html");
 
     SoftAssert softAssert = new SoftAssert();
-    softAssert.assertEquals("Log Folder File Name Directory", logger.getDirectory(),
-            "Expected Directory 'Log Folder File Name Directory'.");
-    softAssert.assertEquals("LogFolderFileName.html", logger.getFileName(), "Expected correct File Name.");
-    softAssert.assertEquals(MessageType.INFORMATION, logger.getMessageType(), "Expected Information Message Type.");
+    softAssert.assertEquals(log_folder_file_name_directory, logger.getDirectory(),
+        "Expected Directory 'Log Folder File Name Directory'.");
+    softAssert.assertEquals("LogFolderFileName.html", logger.getFileName(),
+        "Expected correct File Name.");
+    softAssert.assertEquals(MessageType.INFORMATION, logger.getMessageType(),
+        "Expected Information Message Type.");
 
     softAssert.assertAll();
-
-    File file = new File(logger.getFilePath());
-    file.delete();
   }
 
   /**
@@ -301,18 +306,19 @@ public class HtmlFileLoggerUnitTest {
    */
   @Test
   public void FileLoggerLogFolderMessagingLevel() {
-    HtmlFileLogger logger = new HtmlFileLogger("Log Folder Messaging Level Directory", MessageType.WARNING);
+    final String log_folder_messaging_level_directory_path =
+        LoggingConfig.getLogDirectory() + "/" + "Log Folder Messaging Level Directory";
+    HtmlFileLogger logger = new HtmlFileLogger(log_folder_messaging_level_directory_path,
+        MessageType.WARNING);
 
     SoftAssert softAssert = new SoftAssert();
-    softAssert.assertEquals("Log Folder Messaging Level Directory", logger.getDirectory(),
-            "Expected Directory 'Log Folder Messaging Level Directory'.");
+    softAssert.assertEquals(log_folder_messaging_level_directory_path, logger.getDirectory(),
+        "Expected Directory 'Log Folder Messaging Level Directory'.");
     softAssert.assertEquals("FileLog.html", logger.getFileName(), "Expected correct File Name.");
-    softAssert.assertEquals(MessageType.WARNING, logger.getMessageType(), "Expected Warning Message Type.");
+    softAssert.assertEquals(MessageType.WARNING, logger.getMessageType(),
+        "Expected Warning Message Type.");
 
     softAssert.assertAll();
-
-    File file = new File(logger.getFilePath());
-    file.delete();
   }
 
   /**
@@ -358,19 +364,18 @@ public class HtmlFileLoggerUnitTest {
    */
   @Test
   public void FileLoggerAppendLogFolderFileName() {
-    HtmlFileLogger logger = new HtmlFileLogger(
-            true, "AppendLogFolderFileNameDirectory", "AppendLogFolderFileName.html");
+    final String appendLogFolderFileNameDirectoryPath =
+        LoggingConfig.getLogDirectory() + "/" + "AppendLogFolderFileNameDirectory";
+    HtmlFileLogger logger = new HtmlFileLogger(true, appendLogFolderFileNameDirectoryPath,
+        "AppendLogFolderFileName.html");
 
     SoftAssert softAssert = new SoftAssert();
-    softAssert.assertEquals("AppendLogFolderFileNameDirectory", logger.getDirectory(),
-            " Expected Directory AppendLogFolderFileNameDirectory");
+    softAssert.assertEquals(appendLogFolderFileNameDirectoryPath, logger.getDirectory(),
+        " Expected Directory AppendLogFolderFileNameDirectory");
     softAssert.assertEquals("AppendLogFolderFileName.html", logger.getFileName(), "Expected correct File Name.");
     softAssert.assertEquals(MessageType.INFORMATION, logger.getMessageType(), "Expected Information Message Type.");
 
     softAssert.assertAll();
-
-    File file = new File(logger.getFilePath());
-    file.delete();
   }
 
   /**
@@ -378,12 +383,14 @@ public class HtmlFileLoggerUnitTest {
    */
   @Test
   public void FileLoggerAppendLogFolderMessagingLevel() {
-    HtmlFileLogger logger = new HtmlFileLogger(
-            true, "AppendLogFolderFileNameDirectory", MessageType.WARNING);
+    final String appendLogFolderFileNameDirectory =
+        LoggingConfig.getLogDirectory() + "/" + "AppendLogFolderFileNameDirectory";
+    HtmlFileLogger logger = new HtmlFileLogger(true, appendLogFolderFileNameDirectory,
+        MessageType.WARNING);
 
     SoftAssert softAssert = new SoftAssert();
-    softAssert.assertEquals("AppendLogFolderFileNameDirectory", logger.getDirectory(),
-            " Expected Directory AppendLogFolderFileNameDirectory");
+    softAssert.assertEquals(appendLogFolderFileNameDirectory, logger.getDirectory(),
+        " Expected Directory AppendLogFolderFileNameDirectory");
     softAssert.assertEquals("FileLog.html", logger.getFileName(), "Expected correct File Name.");
     softAssert.assertEquals(MessageType.WARNING, logger.getMessageType(), "Expected Warning Message Type.");
 
@@ -418,15 +425,18 @@ public class HtmlFileLoggerUnitTest {
    */
   @Test
   public void FileLoggerLogFolderFileNameMessagingLevel() {
-    HtmlFileLogger logger = new HtmlFileLogger(
-            "LogFolderFileNameMessagingLevelDirectory", "LogFolderFileNameMessagingLevel.html", MessageType.WARNING);
+    final String logFolderFileNameMessagingLevelDirectoryPath =
+        LoggingConfig.getLogDirectory() + "/" + "LogFolderFileNameMessagingLevelDirectory";
+    HtmlFileLogger logger = new HtmlFileLogger(logFolderFileNameMessagingLevelDirectoryPath,
+        "LogFolderFileNameMessagingLevel.html", MessageType.WARNING);
 
     SoftAssert softAssert = new SoftAssert();
-    softAssert.assertEquals("LogFolderFileNameMessagingLevelDirectory", logger.getDirectory(),
-            "Expected Directory 'LogFolderFileNameMessagingLevelDirectory'");
+    softAssert.assertEquals(logFolderFileNameMessagingLevelDirectoryPath, logger.getDirectory(),
+        "Expected Directory 'LogFolderFileNameMessagingLevelDirectory'");
     softAssert.assertEquals("LogFolderFileNameMessagingLevel.html", logger.getFileName(),
-            "Expected correct File Name.");
-    softAssert.assertEquals(MessageType.WARNING, logger.getMessageType(), "Expected Warning Message Type.");
+        "Expected correct File Name.");
+    softAssert.assertEquals(MessageType.WARNING, logger.getMessageType(),
+        "Expected Warning Message Type.");
 
     softAssert.assertAll();
 


### PR DESCRIPTION
Log files and directory for unit tests now go to target folder as intended.  Resolves #172.