### PR TITLE
JMAQS #314: ClassCastException When Upcasting BaseTest Object to Child After First Iteration of DataProvider with TestNG

### DIFF
--- a/jmaqs-base/src/main/java/com/magenic/jmaqs/base/BaseExtendableTest.java
+++ b/jmaqs-base/src/main/java/com/magenic/jmaqs/base/BaseExtendableTest.java
@@ -29,8 +29,9 @@ public abstract class BaseExtendableTest<T extends BaseTestObject> extends BaseT
 
   @Override
   public void setTestObject(BaseTestObject baseTestObject) {
-
-    if (this.baseTestObjects.putIfAbsent(this.getFullyQualifiedTestClassName(), baseTestObject) == null) {
+    if (!this.baseTestObjects.containsKey(this.getFullyQualifiedTestClassName())) {
+      this.baseTestObjects.put(this.getFullyQualifiedTestClassName(), baseTestObject);
+    } else {
       this.baseTestObjects.replace(this.getFullyQualifiedTestClassName(), baseTestObject);
     }
   }

--- a/jmaqs-base/src/main/java/com/magenic/jmaqs/base/BaseExtendableTest.java
+++ b/jmaqs-base/src/main/java/com/magenic/jmaqs/base/BaseExtendableTest.java
@@ -27,15 +27,6 @@ public abstract class BaseExtendableTest<T extends BaseTestObject> extends BaseT
     return (T) super.getTestObject();
   }
 
-  @Override
-  public void setTestObject(BaseTestObject baseTestObject) {
-    if (!this.baseTestObjects.containsKey(this.getFullyQualifiedTestClassName())) {
-      this.baseTestObjects.put(this.getFullyQualifiedTestClassName(), baseTestObject);
-    } else {
-      this.baseTestObjects.replace(this.getFullyQualifiedTestClassName(), baseTestObject);
-    }
-  }
-
   @BeforeMethod
   @Override
   public void setup(Method method, ITestContext testContext) {

--- a/jmaqs-base/src/main/java/com/magenic/jmaqs/base/ConcurrentManagerHashMap.java
+++ b/jmaqs-base/src/main/java/com/magenic/jmaqs/base/ConcurrentManagerHashMap.java
@@ -81,7 +81,7 @@ public class ConcurrentManagerHashMap extends ConcurrentHashMap<String, BaseTest
    * @param key Key of the item to close
    */
   private void closeForKey(Object key) {
-    if (super.contains(key)) {
+    if (super.containsKey(key)) {
       super.get(key).close();
     }
   }

--- a/jmaqs-base/src/test/java/com/magenic/jmaqs/base/ConcurrentManagerHashMapUnitTest.java
+++ b/jmaqs-base/src/test/java/com/magenic/jmaqs/base/ConcurrentManagerHashMapUnitTest.java
@@ -67,6 +67,9 @@ public class ConcurrentManagerHashMapUnitTest extends BaseTest {
 
     Assert.assertTrue(newHash.containsKey("1"), "Expected item '1'");
     Assert.assertTrue(newHash.containsKey("2"), "Expected item '2'");
+
+    Assert.assertTrue(temp.getClosed());
+    Assert.assertFalse(temp2.getClosed());
   }
 
   @Test(groups = TestCategories.FRAMEWORK)
@@ -84,6 +87,15 @@ public class ConcurrentManagerHashMapUnitTest extends BaseTest {
     Assert.assertTrue(newHash.containsKey("2"), "Expected item '2'");
     Assert.assertTrue(temp.getClosed(), "Expected item old item to be closed");
     Assert.assertFalse(temp2.getClosed(), "Did not expect new item to be closed");
+  }
+
+  @Test
+  public void testReplaceWithNew() {
+    ConcurrentManagerHashMap newHash = new ConcurrentManagerHashMap();
+    newHash.put("1", new BaseTestObject(this.getTestObject()));
+    BaseTestObject temp = new BaseTestObject(this.getTestObject());
+    BaseTestObject temp2 = new BaseTestObject(this.getTestObject());
+    newHash.put("2", temp);
   }
 
   /*

--- a/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/BaseSeleniumTestUnitTest.java
+++ b/jmaqs-selenium/src/test/java/com/magenic/jmaqs/selenium/BaseSeleniumTestUnitTest.java
@@ -8,6 +8,7 @@ import com.magenic.jmaqs.utilities.helper.TestCategories;
 
 import org.openqa.selenium.WebDriver;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -46,13 +47,33 @@ public class BaseSeleniumTestUnitTest extends BaseSeleniumTest {
     try {
       driver = this.getBrowser();
       Assert.assertNotNull(driver,
-          "Checking that Selenium Driver is not null through BaseSeleniumTest");
+              "Checking that Selenium Driver is not null through BaseSeleniumTest");
     } catch (Exception e) {
       e.printStackTrace();
-    }
-    finally{
+    } finally {
       driver.quit();
     }
   }
 
+  @DataProvider(name = "data")
+  public Object[][] getData() {
+    return new Object[][]{
+            {"First"},
+            {"Second"},
+            {"Third"}
+    };
+  }
+
+  /**
+   * Verify issue is resolved with upcasting the BaseTestObject to one of
+   * it's concrete implementation when using TestNG Dataproviders.
+   *
+   * @param data The data being provided for each test
+   * @see <a href=https://github.com/Magenic/JMAQS/issues/314>JMAQS github issue 314</a>
+   */
+  @Test(dataProvider = "data", groups = TestCategories.SELENIUM)
+  public void testUpcastingToSeleniumTestObjectAfterDataProviderIteration(String data) {
+    Assert.assertNotNull(data);
+    Assert.assertTrue(this.getTestObject() instanceof SeleniumTestObject);
+  }
 }


### PR DESCRIPTION
* Updating `setTestObject` method to properly replace the key if a value exists
  - Update: Removed Override in BaseExtendableTest.java because the behavior in BaseTest.java is the same as the new implemenation. No need to override
* fixed `closeForKey` method by using `containsKey()` to correctly check if the key exists
* Added unit test to verify fix with data providers
* Updated unit test for ConcurrentManagerHashMap to check if replaced value is properly closed
