### PR TITLE
Add JMAQS modules to dependency management

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run Unit Tests and SonarCloud Analysis
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: mvn -B -Dtesting verify package sonar:sonar --file pom.xml -e -fae -Dsonar.coverage.jacoco.xmlReportPaths="${{github.workspace}}/jmaqs-jacoco-reporting/target/site/jacoco-aggregate/jacoco.xml" -T 1C
+          run: mvn -Psonar -B -Dtesting verify package sonar:sonar --file pom.xml -e -fae -Dsonar.coverage.jacoco.xmlReportPaths="${{github.workspace}}/jmaqs-jacoco-reporting/target/site/jacoco-aggregate/jacoco.xml" -T 1C
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Test Result Logs

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -28,7 +28,7 @@ jobs:
           profiles: '[{ "id": "sonar", "properties": { "sonar.organization":"magenic", "sonar.host.url":"https://sonarcloud.io", "sonar.login": "${{secrets.SONAR_LOGIN}}" }}]'
           servers: '[{"id": "github", "username": "jason-edstrom", "password": "${{secrets.PACKAGES}}"}]'
       - name: Run Unit Tests and SonarCloud Analysis
-        run: xvfb-run mvn -B -Pjacoco -Psonar verify package sonar:sonar --file pom.xml -e -fae -Dsonar.coverage.jacoco.xmlReportPaths="${{github.workspace}}/jmaqs-jacoco-reporting/target/site/jacoco-aggregate/jacoco.xml" -T 1C
+        run: xvfb-run mvn -B -Dtesting verify package sonar:sonar --file pom.xml -e -fae -Dsonar.coverage.jacoco.xmlReportPaths="${{github.workspace}}/jmaqs-jacoco-reporting/target/site/jacoco-aggregate/jacoco.xml" -T 1C
       - name: Upload Test Result Logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,4 +1,4 @@
-name: Pull Request Build
+name: Pull Request Pipeline
 
 on:
   pull_request:
@@ -8,10 +8,6 @@ jobs:
   unit_tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up XVFB for UI tests
-        run: |
-          sudo apt-get update
-          sudo apt-get install xvfb
       - uses: actions/checkout@v2
       - name: Set up JDK 11
         uses: actions/setup-java@v1
@@ -28,7 +24,11 @@ jobs:
           profiles: '[{ "id": "sonar", "properties": { "sonar.organization":"magenic", "sonar.host.url":"https://sonarcloud.io", "sonar.login": "${{secrets.SONAR_LOGIN}}" }}]'
           servers: '[{"id": "github", "username": "jason-edstrom", "password": "${{secrets.PACKAGES}}"}]'
       - name: Run Unit Tests and SonarCloud Analysis
-        run: xvfb-run mvn -B -Dtesting verify package sonar:sonar --file pom.xml -e -fae -Dsonar.coverage.jacoco.xmlReportPaths="${{github.workspace}}/jmaqs-jacoco-reporting/target/site/jacoco-aggregate/jacoco.xml" -T 1C
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: mvn -B -Dtesting verify package sonar:sonar --file pom.xml -e -fae -Dsonar.coverage.jacoco.xmlReportPaths="${{github.workspace}}/jmaqs-jacoco-reporting/target/site/jacoco-aggregate/jacoco.xml" -T 1C
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Test Result Logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,46 +1,15 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+name: Release Pipeline
 
-name: JMAQS SnapShot Build
-
-#on:
-#  push:
-#  tags:
-#    -v*
 on:
   push:
-    branches: [master]
+  tags:
+    -v*
+
 
 jobs:
-  update_release_draft:
+  release:
     runs-on: ubuntu-latest
     steps:
-      - name: Draft Release notes
-        id: release-drafter
-        uses: release-drafter/release-drafter@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: |
-          version=${{steps.release-drafter.outputs.tag_name}}
-          echo "${version//v}" >> version.txt
-      - name: Upload Version Number
-        uses: actions/upload-artifact@v2
-        with:
-          name: version
-          path: version.txt
-  snapshot_build:
-    runs-on: ubuntu-latest
-    needs: update_release_draft
-    steps:
-      - name: Download version artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: version
-      - name: Store version number in environment variable
-        shell: bash
-        run: |
-          value=`cat version/version.txt`
-          echo ::set-env name=VERSION::$value
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release Pipeline
 
 on:
   push:
-  tags:
-    -v*
+    tags:
+        -v*
 
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: JMAQS SnapShot Build
+
+#on:
+#  push:
+#  tags:
+#    -v*
+on:
+  push:
+    branches: [master]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Draft Release notes
+        id: release-drafter
+        uses: release-drafter/release-drafter@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          version=${{steps.release-drafter.outputs.tag_name}}
+          echo "${version//v}" >> version.txt
+      - name: Upload Version Number
+        uses: actions/upload-artifact@v2
+        with:
+          name: version
+          path: version.txt
+  snapshot_build:
+    runs-on: ubuntu-latest
+    needs: update_release_draft
+    steps:
+      - name: Download version artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: version
+      - name: Store version number in environment variable
+        shell: bash
+        run: |
+          value=`cat version/version.txt`
+          echo ::set-env name=VERSION::$value
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v2
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Maven Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{runner.os}}-m2
+      - name: Create settings file
+        uses: InstaCode/maven-settings-xml-action@v9
+        with:
+          servers: '[{"id": "ossrh", "username": "jason-edstrom", "password": "${{secrets.OSSRH_PACKAGES}}"},{"id": "github", "username": "jason-edstrom", "password": "${{secrets.PACKAGES}}"}]'
+          profiles: '[{ "id": "sonar", "properties": { "sonar.organization":"magenic", "sonar.host.url":"https://sonarcloud.io", "sonar.login": "${{secrets.SONAR_LOGIN}}"}}]'
+      - name: Set Version to ${{env.VERSION}}-SNAPSHOT and Run Unit Tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: mvn -Drevision="${{env.VERSION}}-SNAPSHOT" -Dtesting -T 1C verify install sonar:sonar -B -e -f pom.xml -fae -Dsonar.coverage.jacoco.xmlReportPaths="${{github.workspace}}/jmaqs-jacoco-reporting/target/site/jacoco-aggregate/jacoco.xml"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy Release Packages to Sonatype - Open Source
+        run: mvn -Drevision="${{env.VERSION}}" -Possrh -Drelease deploy -B -e -f pom.xml
+      - name: Deploy Release Packages to GitHub Packages
+        run: mvn -Drevision="${{env.VERSION}}" -Pgithub -Drelease deploy -B -e -f pom.xml
+      - name: Upload Test Result Logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Logs
+          path: ./**/logs

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -61,15 +61,15 @@ jobs:
         uses: InstaCode/maven-settings-xml-action@v9
         with:
           servers: '[{"id": "ossrh", "username": "jason-edstrom", "password": "${{secrets.OSSRH_PACKAGES}}"}]'
-          profiles: '[{ "id": "sonar", "properties": { "sonar.organization":"${{secrets.SONAR_ORG}}", "sonar.host.url":"https://sonarcloud.io", "sonar.login": "${{secrets.SONAR_LOGIN}}"}}]'
+          profiles: '[{ "id": "sonar", "properties": { "sonar.organization":"magenic", "sonar.host.url":"https://sonarcloud.io", "sonar.login": "${{secrets.SONAR_LOGIN}}"}}]'
       - name: Set Version to ${{env.VERSION}}-SNAPSHOT and Run Unit Tests
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: mvn -Drevision="${{env.VERSION}}-SNAPSHOT" -Psonar -Pjacoco -T 1C verify install sonar:sonar -B -e -f pom.xml -fae -Dsonar.coverage.jacoco.xmlReportPaths="${{github.workspace}}/jmaqs-jacoco-reporting/target/site/jacoco-aggregate/jacoco.xml"
+          run: mvn -Drevision="${{env.VERSION}}-SNAPSHOT" -Dtesting -T 1C verify install sonar:sonar -B -e -f pom.xml -fae -Dsonar.coverage.jacoco.xmlReportPaths="${{github.workspace}}/jmaqs-jacoco-reporting/target/site/jacoco-aggregate/jacoco.xml"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy SnapShot Packages to Sonatype - Open Source
-        run: mvn -Possrh deploy -DskipTests -B -e -f pom.xml
+        run: mvn -Drevision="${{env.VERSION}}-SNAPSHOT" -Possrh -Dsnapshot deploy -B -e -f pom.xml
       - name: Upload Test Result Logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set Version to ${{env.VERSION}}-SNAPSHOT and Run Unit Tests
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: mvn -Drevision="${{env.VERSION}}-SNAPSHOT" -Dtesting -T 1C verify install sonar:sonar -B -e -f pom.xml -fae -Dsonar.coverage.jacoco.xmlReportPaths="${{github.workspace}}/jmaqs-jacoco-reporting/target/site/jacoco-aggregate/jacoco.xml"
+          run: mvn -Drevision="${{env.VERSION}}-SNAPSHOT" -Psonar -Dtesting -T 1C verify install sonar:sonar -B -e -f pom.xml -fae -Dsonar.coverage.jacoco.xmlReportPaths="${{github.workspace}}/jmaqs-jacoco-reporting/target/site/jacoco-aggregate/jacoco.xml"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy SnapShot Packages to Sonatype - Open Source

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,12 +1,5 @@
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+name: SnapShot Pipeline
 
-name: JMAQS SnapShot Build
-
-#on:
-#  push:
-#  tags:
-#    -v*
 on:
   push:
     branches: [master]
@@ -28,7 +21,7 @@ jobs:
         with:
           name: version
           path: version.txt
-  snapshot_build:
+  snapshot:
     runs-on: ubuntu-latest
     needs: update_release_draft
     steps:

--- a/jmaqs-appium/pom.xml
+++ b/jmaqs-appium/pom.xml
@@ -43,12 +43,10 @@
         <dependency>
             <groupId>com.magenic.jmaqs.utilities</groupId>
             <artifactId>jmaqs-utilities</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.magenic.jmaqs.base</groupId>
             <artifactId>jmaqs-base</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/jmaqs-base/pom.xml
+++ b/jmaqs-base/pom.xml
@@ -14,25 +14,15 @@
     <name>JMAQS Base Testing Module</name>
     <version>${revision}</version>
     <packaging>jar</packaging>
-    <url>http://maven.apache.org</url>
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <testng.version>7.0.0</testng.version>
-        <reportng.version>1.1.4</reportng.version>
-        <guice.version>4.2.2</guice.version>
-    </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.magenic.jmaqs.utilities</groupId>
             <artifactId>jmaqs-utilities</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.1.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/jmaqs-cucumber/pom.xml
+++ b/jmaqs-cucumber/pom.xml
@@ -42,14 +42,10 @@
         <dependency>
             <groupId>com.magenic.jmaqs.base</groupId>
             <artifactId>jmaqs-base</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.magenic.jmaqs.selenium</groupId>
             <artifactId>jmaqs-selenium</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
@@ -79,12 +75,10 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
         </dependency>
         <dependency>
             <groupId>com.magenic.jmaqs.utilities</groupId>
             <artifactId>jmaqs-utilities</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>

--- a/jmaqs-database/pom.xml
+++ b/jmaqs-database/pom.xml
@@ -34,8 +34,6 @@
         <dependency>
             <groupId>com.magenic.jmaqs.utilities</groupId>
             <artifactId>jmaqs-utilities</artifactId>
-            <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>

--- a/jmaqs-jacoco-reporting/pom.xml
+++ b/jmaqs-jacoco-reporting/pom.xml
@@ -22,7 +22,9 @@
         <profile>
             <id>jacoco</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>testing</name>
+                </property>
             </activation>
             <build>
                 <plugins>
@@ -52,6 +54,15 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -60,37 +71,30 @@
         <dependency>
             <groupId>com.magenic.jmaqs.appium</groupId>
             <artifactId>jmaqs-appium</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.magenic.jmaqs.base</groupId>
             <artifactId>jmaqs-base</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.magenic.jmaqs.utilities</groupId>
             <artifactId>jmaqs-utilities</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.magenic.jmaqs.webservices</groupId>
             <artifactId>jmaqs-webservices-jdk8</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.magenic.jmaqs.database</groupId>
             <artifactId>jmaqs-database</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.magenic.jmaqs.selenium</groupId>
             <artifactId>jmaqs-selenium</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.magenic.jmaqs.cucumber</groupId>
             <artifactId>jmaqs-cucumber</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/jmaqs-selenium/pom.xml
+++ b/jmaqs-selenium/pom.xml
@@ -53,17 +53,14 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>${testng.version}</version>
         </dependency>
         <dependency>
             <groupId>com.magenic.jmaqs.utilities</groupId>
             <artifactId>jmaqs-utilities</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.magenic.jmaqs.base</groupId>
             <artifactId>jmaqs-base</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>

--- a/jmaqs-utilities/pom.xml
+++ b/jmaqs-utilities/pom.xml
@@ -8,10 +8,14 @@
         <artifactId>jmaqs-framework</artifactId>
         <version>${revision}</version>
     </parent>
+
+
     <groupId>com.magenic.jmaqs.utilities</groupId>
     <artifactId>jmaqs-utilities</artifactId>
     <name>JMAQS Testing Utilities Module</name>
     <version>${revision}</version>
+
+
     <properties>
         <commonsconfiguration2.version>2.7</commonsconfiguration2.version>
         <commonsbeanutils.version>1.9.4</commonsbeanutils.version>

--- a/jmaqs-webservices-jdk11/pom.xml
+++ b/jmaqs-webservices-jdk11/pom.xml
@@ -28,6 +28,22 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${javadoc.plugin.version}</version>
                 <executions>

--- a/jmaqs-webservices-jdk8/pom.xml
+++ b/jmaqs-webservices-jdk8/pom.xml
@@ -8,10 +8,12 @@
         <artifactId>jmaqs-framework</artifactId>
         <version>${revision}</version>
     </parent>
+
     <groupId>com.magenic.jmaqs.webservices</groupId>
     <artifactId>jmaqs-webservices-jdk8</artifactId>
     <name>JMAQS JDK8 WebServices Testing Module</name>
     <version>${revision}</version>
+
     <properties>
         <jackson-databind.version>2.10.2</jackson-databind.version>
         <jackson-core.version>2.11.0</jackson-core.version>
@@ -21,6 +23,7 @@
         <jackson-annotations.version>2.11.1</jackson-annotations.version>
         <httpclient.version>4.5.12</httpclient.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -39,12 +42,10 @@
         <dependency>
             <groupId>com.magenic.jmaqs.utilities</groupId>
             <artifactId>jmaqs-utilities</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.magenic.jmaqs.base</groupId>
             <artifactId>jmaqs-base</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.beust</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,11 @@
         <module>jmaqs-base</module>
         <module>jmaqs-selenium</module>
         <module>jmaqs-webservices-jdk8</module>
+        <module>jmaqs-webservices-jdk11</module>
         <module>jmaqs-appium</module>
         <module>jmaqs-database</module>
         <module>jmaqs-cucumber</module>
+        <module>jmaqs-jacoco-reporting</module>
     </modules>
 
     <profiles>
@@ -78,15 +80,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>WIP</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <modules>
-                <module>jmaqs-webservices-jdk11</module>
-            </modules>
         </profile>
         <profile>
             <id>ossrh</id>
@@ -218,9 +211,6 @@
                     <name>testing</name>
                 </property>
             </activation>
-            <modules>
-                <module>jmaqs-jacoco-reporting</module>
-            </modules>
             <build>
                 <plugins>
                     <plugin>
@@ -263,6 +253,41 @@
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.magenic.jmaqs.appium</groupId>
+                <artifactId>jmaqs-appium</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.magenic.jmaqs.base</groupId>
+                <artifactId>jmaqs-base</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.magenic.jmaqs.utilities</groupId>
+                <artifactId>jmaqs-utilities</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.magenic.jmaqs.webservices</groupId>
+                <artifactId>jmaqs-webservices-jdk8</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.magenic.jmaqs.database</groupId>
+                <artifactId>jmaqs-database</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.magenic.jmaqs.selenium</groupId>
+                <artifactId>jmaqs-selenium</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.magenic.jmaqs.cucumber</groupId>
+                <artifactId>jmaqs-cucumber</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -274,13 +299,19 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>${maven-deploy-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.8</version>
+                    <extensions>true</extensions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.2.3</version>
+                <version>1.2.5</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
                     <flattenMode>resolveCiFriendliesOnly</flattenMode>
@@ -356,13 +387,6 @@
                     <parallel>methods</parallel>
                     <threadCount>6</threadCount>
                     <argLine>${argLine}</argLine>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -56,10 +56,29 @@
         <module>jmaqs-cucumber</module>
     </modules>
 
-    <distributionManagement>
-    </distributionManagement>
-
     <profiles>
+        <profile>
+            <id>testing</id>
+            <activation>
+                <property>
+                    <name>testing</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire.plugin.version}</version>
+                        <configuration>
+                            <parallel>methods</parallel>
+                            <threadCount>6</threadCount>
+                            <argLine>${argLine}</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>WIP</id>
             <activation>
@@ -79,66 +98,33 @@
                 <snapshotRepository>
                     <id>ossrh</id>
                     <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-            </distributionManagement>
-        </profile>
-        <profile>
-            <id>github</id>
-            <distributionManagement>
-                <repository>
-                    <id>github</id>
-                    <url>https://maven.pkg.github.com/Magenic/JMAQS</url>
-                </repository>
-                <snapshotRepository>
-                    <id>github</id>
-                    <url>https://maven.pkg.github.com/Magenic/JMAQS</url>
                     <uniqueVersion>true</uniqueVersion>
                 </snapshotRepository>
             </distributionManagement>
         </profile>
         <profile>
-            <id>sonar</id>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>release</name>
+                </property>
+            </activation>
             <properties>
-                <sonar.coverage.jacoco.xmlReportPaths>
-                    ./target/site/jacoco-aggregate/jacoco.xml
-                </sonar.coverage.jacoco.xmlReportPaths>
+                <maven.test.skip>true</maven.test.skip>
             </properties>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonarsource.scanner.maven</groupId>
-                        <artifactId>sonar-maven-plugin</artifactId>
-                        <version>3.7.0.1746</version>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.8</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
                     </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>jacoco</id>
-            <modules>
-                <module>jmaqs-jacoco-reporting</module>
-            </modules>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>${jacoco.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>release-sign-artifacts</id>
-            <build>
-                <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
@@ -157,6 +143,95 @@
                                         <arg>loopback</arg>
                                     </gpgArguments>
                                 </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>snapshot</id>
+            <activation>
+                <property>
+                    <name>snapshot</name>
+                </property>
+            </activation>
+            <properties>
+                <maven.test.skip>true</maven.test.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.8</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <skipStaging>true</skipStaging>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>github</id>
+            <distributionManagement>
+                <repository>
+                    <id>github</id>
+                    <url>https://maven.pkg.github.com/Magenic/JMAQS</url>
+                </repository>
+                <snapshotRepository>
+                    <id>github</id>
+                    <url>https://maven.pkg.github.com/Magenic/JMAQS</url>
+                    <uniqueVersion>true</uniqueVersion>
+                </snapshotRepository>
+            </distributionManagement>
+        </profile>
+        <profile>
+            <id>sonar</id>
+            <activation>
+                <property>
+                    <name>testing</name>
+                </property>
+            </activation>
+            <properties>
+                <sonar.coverage.jacoco.xmlReportPaths>
+                    ./target/site/jacoco-aggregate/jacoco.xml
+                </sonar.coverage.jacoco.xmlReportPaths>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonarsource.scanner.maven</groupId>
+                        <artifactId>sonar-maven-plugin</artifactId>
+                        <version>3.7.0.1746</version>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jacoco</id>
+            <activation>
+                <property>
+                    <name>testing</name>
+                </property>
+            </activation>
+            <modules>
+                <module>jmaqs-jacoco-reporting</module>
+            </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>
@@ -228,17 +303,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler.plugin.version}</version>
@@ -297,6 +361,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The intention is to maintain version consistency throughout the framework without requiring the developer to do it.